### PR TITLE
Fix AtomInspector setting singed field values incorrectly.

### DIFF
--- a/source/parsing/atom_inspector.cpp
+++ b/source/parsing/atom_inspector.cpp
@@ -55,8 +55,12 @@ void AtomInspector::EndDescriptor() {
 void AtomInspector::AddField(char const* name, AP4_UI64 value,
                              FormatHint hint /* = HINT_NONE */) {
   assert(current_atom_or_descriptor_ != nullptr);
+  // Use AP4 formatting to conform to lib expectations + use hints.
+  char str[32];
+  AP4_FormatString(str, sizeof(str), hint == HINT_HEX ? "%llx" : "%lld", value);
+
   QString value_string{};
-  QTextStream(&value_string) << value;
+  QTextStream(&value_string) << str;
   current_atom_or_descriptor_->AddField(QString(name), std::move(value_string));
 }
 


### PR DESCRIPTION
Use the AP4 formatter to get string values for integer fields. This has
the following benefits:
- Better handling of singed values per AP4's expectations.
- Uses the hints provided to the formatter.

Resolves #6