### PR TITLE
Tar artifacts before uploading to avoid file permissions being dropped.

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -28,8 +28,14 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --config $BUILD_TYPE
 
+    # Work around for https://github.com/actions/upload-artifact/issues/38
+    # dropping permissions.
+    - name: tar files
+      working-directory: ${{github.workspace}}/build
+      run: tar -cvf mp4-manipulator.tar mp4-manipulator
+
     - name: Archive build
       uses: actions/upload-artifact@v2
       with:
         name: linux-${{env.BUILD_TYPE}}
-        path: ${{github.workspace}}/build/mp4-manipulator
+        path: ${{github.workspace}}/build/mp4-manipulator.tar

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -36,8 +36,14 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: mkdir mp4-manipulator && mv mp4-manipulator.app mp4-manipulator
 
+    # Work around for https://github.com/actions/upload-artifact/issues/38
+    # dropping permissions.
+    - name: tar files
+      working-directory: ${{github.workspace}}/build/mp4-manipulator
+      run: tar -cvf mp4-manipulator.tar mp4-manipulator.app
+
     - name: Archive build
       uses: actions/upload-artifact@v2
       with:
         name: macos-${{env.BUILD_TYPE}}
-        path: ${{github.workspace}}/build/mp4-manipulator
+        path: ${{github.workspace}}/build/mp4-manipulator/mp4-manipulator.tar


### PR DESCRIPTION
This is a work around for https://github.com/SingingTree/mp4-manipulator/issues/7 while https://github.com/actions/upload-artifact/issues/38 is still an issue.

Packaging proper releases should also help one we get there.