### PR TITLE
Display byte array fields as hex values.

### DIFF
--- a/source/parsing/atom_inspector.cpp
+++ b/source/parsing/atom_inspector.cpp
@@ -84,9 +84,14 @@ void AtomInspector::AddField(char const* name, unsigned char const* bytes,
   assert(current_atom_or_descriptor_ != nullptr);
   QString value_string{};
   QTextStream stream(&value_string);
+  stream << "[";
   for (size_t i = 0; i < byte_count; i++) {
-    stream << bytes[i];
+    stream << QString::asprintf("%02x", bytes[i]);
+    if (i < byte_count - 1) {
+      stream << " ";
+    }
   }
+  stream << "]";
   current_atom_or_descriptor_->AddField(QString(name), std::move(value_string));
 }
 


### PR DESCRIPTION
Changes byte fields to show as things like [02 e3].

FIxes https://github.com/SingingTree/mp4-manipulator/issues/14